### PR TITLE
Fix infinite loading on info pools

### DIFF
--- a/src/components/InfoTotalStats/StatCard.tsx
+++ b/src/components/InfoTotalStats/StatCard.tsx
@@ -7,7 +7,7 @@ interface StatCardProps {
     title: string;
     data: number;
     style: string;
-    format?: boolean
+    format?: boolean;
 }
 
 export function StatCard({ isLoading, title, data, style, format }: StatCardProps) {
@@ -15,12 +15,14 @@ export function StatCard({ isLoading, title, data, style, format }: StatCardProp
         <Card classes={`w-100 pa-1 br-12 ${style}`} isDark={false}>
             <div className={"c-lg mb-1"}>{title}</div>
             <div className={"fs-2 b"}>
-                {!data ? (
+                {isLoading || data === null ? (
                     <span>
                         <Loader size={"2rem"} stroke="white" />
                     </span>
+                ) : format ? (
+                    formatDollarAmount(data)
                 ) : (
-                    format ? formatDollarAmount(data) : data
+                    data
                 )}
             </div>
         </Card>

--- a/src/components/InfoTotalStats/index.tsx
+++ b/src/components/InfoTotalStats/index.tsx
@@ -2,8 +2,7 @@ import { useEffect, useMemo } from "react";
 import { useLocation } from "react-router-dom";
 import { StatCard } from "./StatCard";
 import "./index.scss";
-import { t, Trans } from "@lingui/macro";
-import { AlertCircle } from "react-feather";
+import { t } from "@lingui/macro";
 
 interface InfoTotalStatsProps {
     data: any;


### PR DESCRIPTION
Now it should correct data:

<img width="850" alt="image" src="https://github.com/SwaprHQ/swapr-algebra-ui/assets/5664434/313b5134-eb67-4c0f-a4f7-7adc59db47e9">
