### PR TITLE
fix: token 2 not selecting on when clicking common pairs

### DIFF
--- a/src/pages/NewAddLiquidity/index.tsx
+++ b/src/pages/NewAddLiquidity/index.tsx
@@ -159,11 +159,13 @@ export function NewAddLiquidityPage({
         resetState();
     }, [history, handleCurrencySelect, currencyIdA, currencyIdB]);
 
-    const handlePopularPairSelection = useCallback((pair: [string, string]) => {
-        const WXDAI = "0xe91d153e0b41518a2ce8dd3d7944fa863463a97d";
-        history.push(`/add/${pair[0] === WXDAI ? "WXDAI" : pair[0]}/${pair[1] === WXDAI ? "WXDAI" : pair[1]}`);
-        resetState();
-    }, []);
+    const handlePopularPairSelection = useCallback(
+        (pair: [string, string]) => {
+            history.push(`/add/${pair[0]}/${pair[1]}`);
+            resetState();
+        },
+        [history]
+    );
 
     const handleStepChange = useCallback(
         (_step) => {


### PR DESCRIPTION
<img width="1153" alt="image" src="https://github.com/SwaprHQ/swapr-algebra-ui/assets/23079677/7ebbe4bc-c0e3-415c-8134-b679246ad1af">

XDAI can now be selected.