### PR TITLE
[LIQ-33][FEAT] - Ask for swap exact approval

### DIFF
--- a/src/hooks/useApproveCallback.ts
+++ b/src/hooks/useApproveCallback.ts
@@ -1,4 +1,3 @@
-import { MaxUint256 } from "@ethersproject/constants";
 import { TransactionResponse } from "@ethersproject/providers";
 import { Currency, CurrencyAmount, Percent, TradeType } from "@uniswap/sdk-core";
 import { Trade as V2Trade } from "@uniswap/v2-sdk";
@@ -77,15 +76,15 @@ export function useApproveCallback(amountToApprove?: CurrencyAmount<Currency>, s
             return;
         }
 
-        let useExact = false;
-        const estimatedGas = await tokenContract.estimateGas.approve(spender, MaxUint256).catch(() => {
+        const exactToApprove = amountToApprove.quotient.toString();
+
+        const estimatedGas = await tokenContract.estimateGas.approve(spender, exactToApprove).catch(() => {
             // general fallback for tokens who restrict approval amounts
-            useExact = true;
             return tokenContract.estimateGas.approve(spender, amountToApprove.quotient.toString());
         });
 
         return tokenContract
-            .approve(spender, useExact ? amountToApprove.quotient.toString() : MaxUint256, {
+            .approve(spender, exactToApprove, {
                 gasLimit: calculateGasMargin(chainId, estimatedGas),
                 gasPrice: gasPrice * GAS_PRICE_MULTIPLIER,
             })


### PR DESCRIPTION
## Fixes: [LIQ-33](https://linear.app/swaprhq/issue/LIQ-33/ask-for-swap-exact-approval)

# Description

* Replace useApproveCallback logic to always use exact approve instead infinite approve

# Visual Evidence
![image](https://github.com/SwaprHQ/swapr-algebra-ui/assets/21271189/fb84ae1b-dd03-4fe8-96a7-8cdb9de20743)


# How to test the changes

1) Pull this branch
2) Run the project locally
3) Go to "Swap" header item and select any token to be approved for swap
4) After hitting "Approve Swapr to use your $token" button, your wallet prompt should display the exact amount to be approved for spending, and not a really big amount to be approved.