### PR TITLE
improve UX on info pools row

### DIFF
--- a/src/components/InfoPools/PoolRow.tsx
+++ b/src/components/InfoPools/PoolRow.tsx
@@ -20,21 +20,20 @@ export const Pool = ({ token0, token1, fee, address }: any) => {
 
     return (
         <div className={"f f-jc f-ac"}>
-            <DoubleCurrencyLogo
-                currency0={new Token(AlgebraConfig.CHAIN_PARAMS.chainId, token0?.id, 18, token0.symbol) as WrappedCurrency}
-                currency1={new Token(AlgebraConfig.CHAIN_PARAMS.chainId, token1?.id, 18, token1.symbol) as WrappedCurrency}
-                size={20}
-            />
-            <a className={"link f-ac"} href={`${AlgebraConfig.CHAIN_PARAMS.blockExplorerURL}/address/${address}`} rel="noopener noreferrer" target="_blank">
+            <NavLink className={"link f-ac"} to={`/info/pools/${address}`}>
+                <DoubleCurrencyLogo
+                    currency0={new Token(AlgebraConfig.CHAIN_PARAMS.chainId, token0?.id, 18, token0.symbol) as WrappedCurrency}
+                    currency1={new Token(AlgebraConfig.CHAIN_PARAMS.chainId, token1?.id, 18, token1.symbol) as WrappedCurrency}
+                    size={20}
+                />
                 <TYPE.label ml="8px">
                     {_poolTitle[0]}/{_poolTitle[1]}
                 </TYPE.label>
+            </NavLink>
+            <span className={"fee-badge ml-05 mr-05"}>{feeTierPercent(+fee)}</span>
+            <a className={" hover-op trans-op"} href={`${AlgebraConfig.CHAIN_PARAMS.blockExplorerURL}/address/${address}`} rel="noopener noreferrer" target="_blank">
                 <ExternalLink size={16} color={"var(--white)"} />
             </a>
-            <span className={"fee-badge ml-05 mr-05"}>{feeTierPercent(+fee)}</span>
-            <NavLink className={"chart-link hover-op trans-op"} to={`/info/pools/${address}`}>
-                <BarChart2 size={18} stroke={"var(--primary)"} />
-            </NavLink>
         </div>
     );
 };


### PR DESCRIPTION
This PR improves the UX on info pools row

By changing the links, on clicking the pair it opens pool page, and by clicking external link it opens explorer.

<img width="1086" alt="image" src="https://github.com/SwaprHQ/swapr-algebra-ui/assets/5664434/768925b4-3d0a-4019-8731-6cf3bbf39a7f">
