### PR TITLE
fix: prevent possible infinite loop

### DIFF
--- a/src/components/Header/NetworkCard.tsx
+++ b/src/components/Header/NetworkCard.tsx
@@ -10,23 +10,12 @@ import styled from "styled-components/macro";
 import AlgebraConfig from "algebra.config";
 
 export default function NetworkCard() {
-    const { chainId, connector } = useWeb3React();
+    const { chainId } = useWeb3React();
 
     const node = useRef<HTMLDivElement>(null);
     const open = useModalOpen(ApplicationModal.ARBITRUM_OPTIONS);
     const toggle = useToggleModal(ApplicationModal.ARBITRUM_OPTIONS);
     useOnClickOutside(node, open ? toggle : undefined);
-
-    const [implements3085, setImplements3085] = useState(false);
-    useEffect(() => {
-        // metamask is currently the only known implementer of this EIP
-        // here we proceed w/ a noop feature check to ensure the user's version of metamask supports network switching
-        // if not, we hide the UI
-        if (!chainId) {
-            return;
-        }
-        connector.activate(chainId);
-    }, [chainId, connector]);
 
     const info = chainId ? CHAIN_INFO[chainId] : undefined;
     if (!chainId || !info) {

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -135,16 +135,13 @@ export default function Header() {
                 </div>
 
                 <div className={"header__account flex-s-between"}>
-                    {account && (
-                        <>
-                            <NetworkCard />
-                            {(chainId === AlgebraConfig.CHAIN_PARAMS.chainId && account && userEthBalance) || networkFailed ? (
-                                <BalanceText style={{ flexShrink: 0 }} px="0.85rem" fontWeight={500}>
-                                    {_userEthBalance?.toFixed(5)} {!isMobile && chainValue}
-                                </BalanceText>
-                            ) : null}
-                        </>
-                    )}
+                    <NetworkCard />
+
+                    {(account && chainId === AlgebraConfig.CHAIN_PARAMS.chainId && userEthBalance) || networkFailed ? (
+                        <BalanceText style={{ flexShrink: 0 }} px="0.85rem" fontWeight={500}>
+                            {_userEthBalance?.toFixed(5)} {!isMobile && chainValue}
+                        </BalanceText>
+                    ) : null}
                     <Web3Status />
                 </div>
             </div>


### PR DESCRIPTION
Hey folks!

While I was investigating [an issue](https://github.com/gnosisguild/zodiac-pilot/issues/154) over at Zodiac pilot, I discovered the reason to possibly be somewhere inside the `swapr-algebra-ui` code.

Once people want to use Swapr with the Zodiac pilot browser extension, we see an infinite loop. I could not figure out the root problem but found a possible fix. The `NetworkCard` component will only render when an `account` is present. Upon rendering, it calls `activate,` which clears the accounts, which will cause it to unmount. Once the accounts are present, they will mount again, and the cycle starts. I'm unsure why this only happens once our browser extension is present. We suspect a timing issue because once we pause the page for a second and then resume the script execution, it works perfectly. 

Luckily, it does not seem like the `NetworkCard` component requires an account to function correctly, as it only displays the current network's name. So we don't need to render it conditionally, which fixes the issue our users see.

If you have any other (and maybe even better) ideas on how to tackle this issue, please let me know.