### PR TITLE
[FIX][LIQ-37] - Pools table takes long time load

### DIFF
--- a/codegen.yml
+++ b/codegen.yml
@@ -1,9 +1,9 @@
 overrideExisting: true
 schema:
   [
-    "https://swaprhq.io/subgraphs/name/swapr/dogechain-info",
-    "https://swaprhq.io/subgraphs/name/swapr/dogechain-farming",
-    "https://swaprhq.io/subgraphs/name/swapr/dogechain-blocklytics",
+    "https://api.studio.thegraph.com/query/63508/algebra-v19/version/latest",
+    "https://api.studio.thegraph.com/query/63508/algebrafarming-v19/version/latest",
+    "https://api.studio.thegraph.com/query/63508/algebrablocks-v19/version/latest",
   ]
 documents: "src/**/!(*.d).{ts,tsx}"
 generates:

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -54,7 +54,7 @@ export async function fetchPoolsAPR() {
     const apiURL = AlgebraConfig.API.poolsAPR;
 
     try {
-        return await fetch(apiURL).then((v) => v.json());
+        return await fetch(apiURL, { signal: AbortSignal.timeout(5000) }).then((v) => v.json());
     } catch (error: any) {
         return {};
     }


### PR DESCRIPTION
 ## Fixes: [LIQ-37](https://linear.app/swaprhq/issue/LIQ-37/pools-table-takes-long-time-load)

## Description
* Updates The Graph schemas
* Adds an abort signal to the API call, to cancel it after 5 sec waiting

## Visual Evidence
https://www.loom.com/share/a04d2924dc7e4ae5a735a37f22eb346c?sid=926ec420-6a6f-42c7-8815-e2b59ca0cc5b